### PR TITLE
Restore tests affected by permission issues

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ test:
     - rm tests/test_utils_asyncio.py  # [win or py==38]                                                                                                                                                            # [win]
     - rm -f tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_downloader_handlers.py  # [osx]
     # Test failures since Scrapy 2.4:
-    - rm -f tests/test_crawler.py tests/test_feedexport.py
+    - rm -f tests/test_command_check.py tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_feedexport.py
     # Tests need to be fixed in upstream.
     - pytest _scrapy tests
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,6 @@ test:
     - pip install mitmproxy pytest-twisted sybil  # [not win or not py==38]
     - pip install pytest-twisted sybil  # [win and py==38]
     - mv scrapy _scrapy
-    - rm tests/test_command_check.py tests/test_command_parse.py tests/test_commands.py  # permission issues
     - rm tests/test_proxy_connect.py  # [win or py==38]
     # https://github.com/scrapy/scrapy/issues/2653#issuecomment-598610517
     - rm tests/test_utils_asyncio.py  # [win or py==38]                                                                                                                                                            # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 0
+  number: 1
   skip: true  # [py2k]
   entry_points:
     - scrapy = scrapy.cmdline:execute


### PR DESCRIPTION
https://github.com/scrapy/scrapy/pull/4722 should have fixed them.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
