### PR TITLE
Restore macOS tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 2
+  number: 3
   skip: true  # [py2k]
   entry_points:
     - scrapy = scrapy.cmdline:execute

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,11 +80,9 @@ test:
     - pip install 'mitmproxy>=4.0.4,<5'  # [py>=36 and py<37]
     - mv scrapy _scrapy
     # https://github.com/scrapy/scrapy/issues/2653#issuecomment-598610517
-    - rm tests/test_utils_asyncio.py  # [win or py==38]                                                                                                                                                            # [win]
-    - rm -f tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_downloader_handlers.py  # [osx]
+    - rm tests/test_utils_asyncio.py  # [win or py==38]
     # Test failures since Scrapy 2.4:
     - rm -f tests/test_command_check.py tests/test_command_parse.py tests/test_commands.py tests/test_crawler.py tests/test_feedexport.py
-    # Tests need to be fixed in upstream.
     - pytest _scrapy tests
 
 about:


### PR DESCRIPTION
Let’s see if these can run now, and if not, how they fail. No high hopes, though, given we get random macOS test failures upstream.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number
* [ ] ~~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~~ (done [very recently](https://github.com/conda-forge/scrapy-feedstock/pull/50))
* [x] Ensured the license file is being packaged.