### PR TITLE
Make http2 optional

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
-  number: 1
+  number: 2
   skip: true  # [py2k]
   entry_points:
     - scrapy = scrapy.cmdline:execute
@@ -50,6 +50,8 @@ requirements:
     - zope.interface >=4.1.3
     - protego >=0.1.15
     - itemadapter >=0.1.0
+
+  run_constrained:
     # deps of twisted[http2]
     - h2 >=3.0, <4.0
     - priority >=1.1.0, <2.0


### PR DESCRIPTION
h2 is optional to twisted, is it same to scrapy?
This could make scrapy build on python 3.9 because `h2 >=3.0, <4.0` is supported up to python 3.8 .